### PR TITLE
Removed Gist Debugger feature

### DIFF
--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -96,6 +96,4 @@ Pasting Errors
 --------------
 
 If you click on the "Traceback (most recent call last)" header, the
-view switches to a tradition text-based traceback. The text can be
-copied, or automatically pasted to `gist.github.com
-<https://gist.github.com>`_ with one click.
+view switches to a tradition text-based traceback.

--- a/src/werkzeug/debug/shared/debugger.js
+++ b/src/werkzeug/debug/shared/debugger.js
@@ -31,42 +31,10 @@ $(function() {
      */
     addNoJSPrompt(document.querySelectorAll("span.nojavascript"))
 
-
-    /**
-     * Add the pastebin feature
-     */
-    $('div.plain form')
-        .submit(function() {
-            var label = $('input[type="submit"]', this);
-            var old_val = label.val();
-            label.val('submitting...');
-            $.ajax({
-                dataType: 'json',
-                url: document.location.pathname,
-                data: {
-                    __debugger__: 'yes',
-                    tb: TRACEBACK,
-                    cmd: 'paste',
-                    s: SECRET
-                },
-                success: function(data) {
-                    $('div.plain span.pastemessage')
-                        .removeClass('pastemessage')
-                        .text('Paste created: ')
-                        .append($('<a>#' + data.id + '</a>').attr('href', data.url));
-                },
-                error: function() {
-                    alert('Error: Could not submit paste.  No network connection?');
-                    label.val(old_val);
-                }
-            });
-            return false;
-        });
-
-    // if we have javascript we submit by ajax anyways, so no need for the
-    // not scaling textarea.
-    var plainTraceback = $('div.plain textarea');
-    plainTraceback.replaceWith($('<pre>').text(plainTraceback.text()));
+  // if we have javascript we submit by ajax anyways, so no need for the
+  // not scaling textarea.
+  var plainTraceback = $('div.plain textarea');
+  plainTraceback.replaceWith($('<pre>').text(plainTraceback.text()));
 });
 
 function initPinBox() {

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -87,16 +87,10 @@ PAGE_HTML = (
 <h2 class="traceback">Traceback <em>(most recent call last)</em></h2>
 %(summary)s
 <div class="plain">
-  <form action="/?__debugger__=yes&amp;cmd=paste" method="post">
     <p>
-      <input type="hidden" name="language" value="pytb">
-      This is the Copy/Paste friendly version of the traceback.  <span
-      class="pastemessage">You can also paste this traceback into
-      a <a href="https://gist.github.com/">gist</a>:
-      <input type="submit" value="create paste"></span>
+      This is the Copy/Paste friendly version of the traceback.
     </p>
     <textarea cols="50" rows="10" name="code" readonly>%(plaintext)s</textarea>
-  </form>
 </div>
 <div class="explanation">
   The debugger caught an exception in your WSGI application.  You can now


### PR DESCRIPTION
Removed gist feature as the new version requires the use of an auth token, and it gets out of the scope of the debugger.